### PR TITLE
Feat/#6 link seoul station api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	// h2
-	runtimeOnly 'com.h2database:h2'
+	// JSON 문자열을 파싱하거나 생성할 수 있는 JSON 처리 라이브러리
+	implementation 'org.json:json:20250107'
 }
 
 tasks.named('test') {

--- a/src/main/java/server/gooroomi/domain/bus/api/BusInfoApiClient.java
+++ b/src/main/java/server/gooroomi/domain/bus/api/BusInfoApiClient.java
@@ -1,0 +1,53 @@
+package server.gooroomi.domain.bus.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+
+@Component
+@RequiredArgsConstructor
+public class BusInfoApiClient {
+
+    @Value("${openapi.bus.key}")
+    private String serviceKey;
+
+    /**
+     * 정류소 번호(arsId)를 이용해 도착 예정 버스 목록을 조회
+     */
+    public String getBusArrivals(String arsId) {
+        try {
+            String url = "http://ws.bus.go.kr/api/rest/stationinfo/getStationByUid";
+            StringBuilder urlBuilder = new StringBuilder(url);
+            urlBuilder.append("?serviceKey=").append(serviceKey);
+            urlBuilder.append("&arsId=").append(URLEncoder.encode(arsId, "UTF-8"));
+            urlBuilder.append("&resultType=json");
+
+            HttpURLConnection conn = (HttpURLConnection) new URL(urlBuilder.toString()).openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Content-type", "application/json");
+
+            BufferedReader rd = new BufferedReader(new InputStreamReader(
+                    conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300 ?
+                            conn.getInputStream() : conn.getErrorStream()
+            ));
+
+            StringBuilder response = new StringBuilder();
+            String line;
+            while ((line = rd.readLine()) != null) {
+                response.append(line);
+            }
+            rd.close();
+            conn.disconnect();
+
+            return response.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("버스 도착 정보 조회 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/server/gooroomi/domain/bus/api/StationInfoApiClient.java
+++ b/src/main/java/server/gooroomi/domain/bus/api/StationInfoApiClient.java
@@ -1,0 +1,55 @@
+package server.gooroomi.domain.bus.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+
+@Component
+@RequiredArgsConstructor
+public class StationInfoApiClient {
+
+    @Value("${openapi.bus.key}")
+    private String serviceKey;
+
+    /**
+     * 사용자 위치(위도, 경도)와 반경을 이용해 근처 버스 정류소 목록을 조회
+     */
+    public String getNearbyStations(Double latitude, Double longitude, int radius) {
+        try {
+            String url = "http://ws.bus.go.kr/api/rest/stationinfo/getStationByPos";
+            StringBuilder urlBuilder = new StringBuilder(url);
+            urlBuilder.append("?serviceKey=").append(serviceKey);
+            urlBuilder.append("&tmX=").append(URLEncoder.encode(latitude.toString(), "UTF-8"));
+            urlBuilder.append("&tmY=").append(URLEncoder.encode(longitude.toString(), "UTF-8"));
+            urlBuilder.append("&radius=").append(radius);
+            urlBuilder.append("&resultType=json");
+
+            HttpURLConnection conn = (HttpURLConnection) new URL(urlBuilder.toString()).openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Content-type", "application/json");
+
+            BufferedReader rd = new BufferedReader(new InputStreamReader(
+                    conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300 ?
+                            conn.getInputStream() : conn.getErrorStream()
+            ));
+
+            StringBuilder response = new StringBuilder();
+            String line;
+            while ((line = rd.readLine()) != null) {
+                response.append(line);
+            }
+            rd.close();
+            conn.disconnect();
+
+            return response.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("정류소 조회 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/server/gooroomi/domain/bus/application/BusArrivalInfoService.java
+++ b/src/main/java/server/gooroomi/domain/bus/application/BusArrivalInfoService.java
@@ -1,0 +1,49 @@
+package server.gooroomi.domain.bus.application;
+
+import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+import server.gooroomi.domain.bus.api.BusInfoApiClient;
+import server.gooroomi.domain.bus.entity.BusArrival;
+import server.gooroomi.domain.bus.entity.BusStation;
+import server.gooroomi.domain.bus.repository.BusArrivalRepository;
+import server.gooroomi.domain.bus.repository.BusStationRepository;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class BusArrivalInfoService {
+
+    private final BusInfoApiClient busInfoApiClient;
+    private final BusArrivalRepository busArrivalRepository;
+    private final BusStationRepository busStationRepository;
+
+    public void saveBusArrivalInfo(String arsId) {
+        String json = busInfoApiClient.getBusArrivals(arsId);
+        BusStation busStation = busStationRepository.findByArsId(arsId);
+        busStation.getBusArrivals().clear();
+
+        JSONObject root = new JSONObject(json);
+        JSONArray itemList = root.getJSONObject("msgBody").optJSONArray("itemList");
+
+        List<BusArrival> busArrivals = IntStream.range(0, itemList.length())
+                .mapToObj(i -> {
+                    JSONObject item = itemList.getJSONObject(i);
+                    String busNumber = item.getString("rtNm");
+                    String arrivalTime = item.getString("traTime1");
+
+                    BusArrival busArrival = BusArrival.builder()
+                            .busNumber(busNumber)
+                            .arrivalTime(arrivalTime)
+                            .build();
+                    busArrival.assignBusStation(busStation);
+                    return busArrival;
+                })
+                .toList();
+
+        busArrivalRepository.saveAll(busArrivals);
+    }
+}

--- a/src/main/java/server/gooroomi/domain/bus/application/BusStationAssignService.java
+++ b/src/main/java/server/gooroomi/domain/bus/application/BusStationAssignService.java
@@ -1,0 +1,50 @@
+package server.gooroomi.domain.bus.application;
+
+import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+import server.gooroomi.domain.bus.api.StationInfoApiClient;
+import server.gooroomi.domain.bus.converter.BusConverter;
+import server.gooroomi.domain.bus.entity.BusStation;
+import server.gooroomi.domain.bus.repository.BusStationRepository;
+import server.gooroomi.domain.user.entity.User;
+import server.gooroomi.global.handler.response.BaseException;
+import server.gooroomi.global.handler.response.BaseResponseStatus;
+
+@Service
+@RequiredArgsConstructor
+public class BusStationAssignService {
+
+    private final StationInfoApiClient stationInfoApiClient;
+    private final BusStationRepository busStationRepository;
+    private final BusArrivalInfoService busArrivalInfoService;
+
+    public void saveBusStation(User user) {
+        String json = stationInfoApiClient.getNearbyStations(user.getLongitude(), user.getLatitude(), 100);
+
+        JSONObject root = new JSONObject(json);
+        JSONArray itemList = root.getJSONObject("msgBody").optJSONArray("itemList");
+
+        if(itemList == null || itemList.isEmpty()){
+            throw new BaseException(BaseResponseStatus.NOT_FOUND_STATION);
+        }
+
+        JSONObject nearest = itemList.getJSONObject(0);
+        String arsId = nearest.getString("arsId");
+        String stationNm = nearest.getString("stationNm");
+
+        BusStation existingBusStation = busStationRepository.findByUser(user);
+
+        if (existingBusStation == null) {
+            BusStation newBusStation = BusConverter.toBusStation(arsId, stationNm, user);
+            busStationRepository.save(newBusStation);
+        } else if (!existingBusStation.getArsId().equals(arsId)) {
+            busStationRepository.delete(existingBusStation);
+            BusStation newBusStation = BusConverter.toBusStation(arsId, stationNm, user);
+            busStationRepository.save(newBusStation);
+        }
+
+        busArrivalInfoService.saveBusArrivalInfo(arsId);
+    }
+}

--- a/src/main/java/server/gooroomi/domain/bus/converter/BusConverter.java
+++ b/src/main/java/server/gooroomi/domain/bus/converter/BusConverter.java
@@ -1,0 +1,14 @@
+package server.gooroomi.domain.bus.converter;
+
+import server.gooroomi.domain.bus.entity.BusStation;
+import server.gooroomi.domain.user.entity.User;
+
+public class BusConverter {
+    public static BusStation toBusStation(String arsId, String stationNm, User user) {
+        return BusStation.builder()
+                .arsId(arsId)
+                .stationName(stationNm)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/server/gooroomi/domain/bus/entity/BusArrival.java
+++ b/src/main/java/server/gooroomi/domain/bus/entity/BusArrival.java
@@ -1,0 +1,38 @@
+package server.gooroomi.domain.bus.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.gooroomi.domain.user.entity.BaseTimeEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class BusArrival extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bus_arrival_id")
+    private Long id;
+
+    private String busNumber;  // 버스 번호
+    private String arrivalTime;  // 도착 시간 (초)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bus_station_id")
+    private BusStation busStation;
+
+    @Builder
+    public BusArrival(String busNumber, String arrivalTime, BusStation busStation) {
+        this.busNumber = busNumber;
+        this.arrivalTime = arrivalTime;
+        this.busStation = busStation;
+    }
+
+    public void assignBusStation(BusStation busStation) {
+        this.busStation = busStation;
+        busStation.getBusArrivals().add(this);
+    }
+}

--- a/src/main/java/server/gooroomi/domain/bus/entity/BusStation.java
+++ b/src/main/java/server/gooroomi/domain/bus/entity/BusStation.java
@@ -1,0 +1,40 @@
+package server.gooroomi.domain.bus.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.gooroomi.domain.user.entity.BaseTimeEntity;
+import server.gooroomi.domain.user.entity.User;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class BusStation extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bus_station_id")
+    private Long id;
+
+    private String arsId; // 정류소 번호
+    private String stationName; // 정류소명
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "busStation", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BusArrival> busArrivals = new ArrayList<>();
+
+    @Builder
+    public BusStation(String arsId, String stationName, User user) {
+        this.arsId = arsId;
+        this.stationName = stationName;
+        this.user = user;
+    }
+}

--- a/src/main/java/server/gooroomi/domain/bus/repository/BusArrivalRepository.java
+++ b/src/main/java/server/gooroomi/domain/bus/repository/BusArrivalRepository.java
@@ -1,0 +1,9 @@
+package server.gooroomi.domain.bus.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import server.gooroomi.domain.bus.entity.BusArrival;
+
+@Repository
+public interface BusArrivalRepository extends JpaRepository<BusArrival, Long> {
+}

--- a/src/main/java/server/gooroomi/domain/bus/repository/BusStationRepository.java
+++ b/src/main/java/server/gooroomi/domain/bus/repository/BusStationRepository.java
@@ -1,0 +1,12 @@
+package server.gooroomi.domain.bus.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import server.gooroomi.domain.bus.entity.BusStation;
+import server.gooroomi.domain.user.entity.User;
+
+@Repository
+public interface BusStationRepository extends JpaRepository<BusStation, Long> {
+    BusStation findByArsId(String arsId);
+    BusStation findByUser(User user);
+}

--- a/src/main/java/server/gooroomi/domain/user/application/UserService.java
+++ b/src/main/java/server/gooroomi/domain/user/application/UserService.java
@@ -3,6 +3,7 @@ package server.gooroomi.domain.user.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import server.gooroomi.domain.bus.application.BusStationAssignService;
 import server.gooroomi.domain.user.converter.UserConverter;
 import server.gooroomi.domain.user.dto.UserBusRequestDto;
 import server.gooroomi.domain.user.dto.UserBusResponseDto;
@@ -18,6 +19,7 @@ import server.gooroomi.global.handler.response.BaseResponseStatus;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final BusStationAssignService busStationAssignService;
 
     @Transactional
     public BaseResponse<UserBusResponseDto> saveUserBusInfo(UserBusRequestDto requestDto) {
@@ -31,8 +33,8 @@ public class UserService {
     public BaseResponse<Object> saveUserLocation(UserLocationRequestDto requestDto) {
         User user = userRepository.findById(requestDto.getUserId())
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_USER));
-
         user.updateLocation(requestDto.getLatitude(), requestDto.getLongitude());
+        busStationAssignService.saveBusStation(user);
         return BaseResponse.success();
     }
 }

--- a/src/main/java/server/gooroomi/domain/user/entity/User.java
+++ b/src/main/java/server/gooroomi/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package server.gooroomi.domain.user.entity;
 
+
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,8 +20,7 @@ public class User extends BaseTimeEntity {
 
     private Double latitude;  // 위도 (Y)
     private Double longitude; // 경도 (X)
-
-    private String busNumber;
+    private String busNumber; // 사용자가 탑승하고자 하는 버스 번호
 
     @Builder
     public User(String busNumber) {

--- a/src/main/java/server/gooroomi/global/handler/response/BaseResponseStatus.java
+++ b/src/main/java/server/gooroomi/global/handler/response/BaseResponseStatus.java
@@ -40,6 +40,7 @@ public enum BaseResponseStatus {
      */
     NOT_FOUND( false,404, HttpStatus.NOT_FOUND,"Not Found"),
     NOT_FOUND_USER(false,40401, HttpStatus.NOT_FOUND,"해당 User를 찾을 수 없습니다"),
+    NOT_FOUND_STATION(false,40402, HttpStatus.NOT_FOUND,"주변에 정류장이 없습니다"),
 
     /**
      * 405 METHOD_NOT_ALLOWED 지원하지 않은 method 호출

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,3 +12,7 @@ spring:
 logging:
   file:
     path: ./gooroomi-dev-logs
+
+openapi:
+  bus:
+    key: ${OPEN_API_KEY}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,9 +6,13 @@ spring:
     password: ${LOCAL_DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
 
 logging:
   file:
     path: ./gooroomi-local-logs
+
+openapi:
+  bus:
+    key: ${OPEN_API_KEY}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,3 +12,7 @@ spring:
 logging:
   file:
     path: ./gooroomi-prod-logs
+
+openapi:
+  bus:
+    key: ${OPEN_API_KEY}


### PR DESCRIPTION
## #️⃣연관된 이슈
> resolved #6 

## 📝작업 내용
- 사용자의 위치를 기반으로 가장 가까운 버스 정류소를 조회하는 기능 구현
- 정류소에 도착 예정인 버스 목록을 조회하여 저장하는 기능 구현
- 주변에 정류소가 없는 경우에 대한 예외 처리 추가

## 🔎코드 설명 및 참고 사항
- 공공데이터포털 서울특별시 OpenAPI (서울특별시_정류소정보조회) 연동 
- 사용자의 위치 정보를 등록할 때, 가장 가까운 정류소와 도착 버스 정보를 함께 저장
- 반경 100m 내에서 가장 가까운 정류소를 탐색하도록 기본 설정